### PR TITLE
Fix #4, killing warnings

### DIFF
--- a/lib/evented-spec/amqp_spec.rb
+++ b/lib/evented-spec/amqp_spec.rb
@@ -15,10 +15,10 @@ module EventedSpec
     module ClassMethods
       def it(*args, &block)
         if block
-          new_block = lambda do |*args|
+          new_block = lambda do |*args_block|
             amqp(&block)
           end
-          super(*args, &new_block)
+          super(*args_block, &new_block)
         else
           # pending example
           super

--- a/lib/evented-spec/coolio_spec.rb
+++ b/lib/evented-spec/coolio_spec.rb
@@ -14,10 +14,10 @@ module EventedSpec
         if block
           # Shared example groups seem to pass example group instance
           # to the actual example block
-          new_block = lambda do |*args|
+          new_block = lambda do |*args_block|
             coolio(&block)
           end
-          super(*args, &new_block)
+          super(*args_block, &new_block)
         else
           # pending example
           super

--- a/lib/evented-spec/em_spec.rb
+++ b/lib/evented-spec/em_spec.rb
@@ -14,10 +14,10 @@ module EventedSpec
         if block
           # Shared example groups seem to pass example group instance
           # to the actual example block
-          new_block = lambda do |*args|
+          new_block = lambda do |*args_block|
             em(&block)
           end
-          super(*args, &new_block)
+          super(*args_block, &new_block)
         else
           # pending example
           super

--- a/lib/evented-spec/evented_example/em_example.rb
+++ b/lib/evented-spec/evented_example/em_example.rb
@@ -40,6 +40,7 @@ module EventedSpec
 
       # See {EventedExample#timeout}
       def timeout(spec_timeout)
+        @spec_timer ||= nil
         EM.cancel_timer(@spec_timer) if @spec_timer
         @spec_timer = EM.add_timer(spec_timeout) do
           @spec_exception = SpecTimeoutExceededError.new "Example timed out"

--- a/lib/evented-spec/ext/amqp.rb
+++ b/lib/evented-spec/ext/amqp.rb
@@ -22,7 +22,7 @@ module AMQP
   def self.start_connection(opts={}, &block)
     if amqp_pre_08?
       self.connection = connect opts
-      self.connection.callback &block
+      self.connection.callback(&block)
     else
       self.connection = connect opts, &block
     end

--- a/lib/evented-spec/spec_helper.rb
+++ b/lib/evented-spec/spec_helper.rb
@@ -42,6 +42,7 @@ module EventedSpec
       #
       # @return [Hash] hash with example group metadata
       def evented_spec_metadata
+        @evented_spec_metadata ||= nil
         if @evented_spec_metadata
           @evented_spec_metadata
         else
@@ -126,7 +127,7 @@ module EventedSpec
     #
     # @param [Float] Delay before event loop is stopped
     def done(*args, &block)
-      @evented_example.done *args, &block if @evented_example
+      @evented_example.done(*args, &block) if @evented_example
     end
 
     # Manually sets timeout for currently running example. If spec doesn't call
@@ -134,7 +135,7 @@ module EventedSpec
     #
     # @param [Float] Delay before event loop is stopped with error
     def timeout(*args)
-      @evented_example.timeout *args if @evented_example
+      @evented_example.timeout(*args) if @evented_example
     end
 
   end # module SpecHelper


### PR DESCRIPTION
Run RSpec with `config.warnings = true` on is always a good idea.